### PR TITLE
Fix typo

### DIFF
--- a/markdown-style-guide.md
+++ b/markdown-style-guide.md
@@ -1384,7 +1384,7 @@ Good:
 
     - get on top of the bike. This step is easy.
     - put your foot on the pedal.
-    - push t the pedal. This is the most fun part.
+    - push the pedal. This is the most fun part.
 
 because it could be replaced with:
 


### PR DESCRIPTION
Fixes this typo in `markdown-style-guide.md`:

```diff
-    - push t the pedal. This is the most fun part.
+    - push the pedal. This is the most fun part.
```